### PR TITLE
Add support for longitudinal projects

### DIFF
--- a/HeadCircChart.php
+++ b/HeadCircChart.php
@@ -146,7 +146,7 @@ class HeadCircChart extends AbstractExternalModule
 		$circumferenceField = $this->getProjectSetting("circumference-field");
 		$debugMode = $this->getProjectSetting("debug-mode");
 		
-		list($sex,$age,$circumference,$height,$weight,$useFentonChart) = $this->getChartDataForRecord($project_id,$record,$event_id,$instrument,$repeat_instance);
+		list($sex,$age,$circumference,$height,$weight,$useFentonChart, $highlightedDatumIndex) = $this->getChartDataForRecord($project_id,$record,$event_id,$instrument,$repeat_instance);
 		
 		$circInstrument = $this->getProject()->getFormForField($headChartField);
 		$heightInstrument = $this->getProject()->getFormForField($heightChartField);
@@ -166,22 +166,24 @@ class HeadCircChart extends AbstractExternalModule
 			
 			## Insert head circumference chart if data exists
 			if(count($circumference) > 0 && $headChartField && $instrument == $circInstrument) {
-				$this->addChartToDataEntryForm($sex,"headCirc",$useFentonChart,$age,$circumference,$repeat_instance,$headChartField,$debugMode);
+				$this->addChartToDataEntryForm($sex,"headCirc",$useFentonChart,$age,$circumference,$highlightedDatumIndex,$headChartField,$debugMode);
 			}
 			
 			## Insert height chart if data exists
 			if(count($height) > 0 && $heightChartField && $instrument == $heightInstrument) {
-				$this->addChartToDataEntryForm($sex,"height",$useFentonChart,$age,$height,$repeat_instance,$heightChartField,$debugMode);
+				$this->addChartToDataEntryForm($sex,"height",$useFentonChart,$age,$height,$highlightedDatumIndex,$heightChartField,$debugMode);
 			}
 			
 			## Insert weight chart if data exists
 			if(count($weight) > 0 && $weightChartField && $instrument == $weightInstrument) {
-				$this->addChartToDataEntryForm($sex,"weight",$useFentonChart,$age,$weight,$repeat_instance,$weightChartField,$debugMode);
+				$this->addChartToDataEntryForm($sex,"weight",$useFentonChart,$age,$weight,$highlightedDatumIndex,$weightChartField,$debugMode);
 			}
 		}
 	}
 	
 	function getChartDataForRecord($projectId,$record,$eventId,$instrument,$repeatInstance,$tempAge = false,$tempValue = false,$tempType = false) {
+		$highlightedDatumIndex = $repeatInstance;
+
 		$sexField = $this->getProjectSetting("sex-field");
 		$gestationalAgeField = $this->getProjectSetting("gestational-age-field");
 		$femaleValue = $this->getProjectSetting("female-value");
@@ -199,13 +201,14 @@ class HeadCircChart extends AbstractExternalModule
 		$useFentonChart = false;
 		
 		$recordData = $this->getRecordData($projectId,$record,$eventId);
-		
+
 		if($femaleValue === "" || $maleValue === "" || $sexField === "" || $ageField === "") {
 			return [$sex,$age,$circumference,$height,$weight,$useFentonChart];
 		}
 		
 		$foundInstance = false;
 		
+		$i = 1;
 		foreach($recordData as $eventDetails) {
 			if($eventDetails[$sexField] !== "") {
 				$sex = ($eventDetails[$sexField] === (string)$femaleValue ? "2" :
@@ -214,7 +217,7 @@ class HeadCircChart extends AbstractExternalModule
 			if($eventDetails[$gestationalAgeField] !== "") {
 				$gestationalAge = $eventDetails[$gestationalAgeField];
 			}
-			
+
 			if($eventDetails["redcap_repeat_instrument"] == $instrument) {
 				if($eventDetails[$ageField] !== "") {
 					$age[$eventDetails["redcap_repeat_instance"]] = $eventDetails[$ageField];
@@ -286,7 +289,7 @@ class HeadCircChart extends AbstractExternalModule
 			}
 		}
 		
-		return [$sex,$age,$circumference,$height,$weight,$useFentonChart];
+		return [$sex,$age,$circumference,$height,$weight,$useFentonChart, $highlightedDatumIndex];
 	}
 	
 	function addChartToDataEntryForm($sex,$chartType,$useFentonChart,$age,$values,$repeat_instance,$chartField,$debugMode) {

--- a/config.json
+++ b/config.json
@@ -27,96 +27,111 @@
 	  ]
 	},
 
-	"project-settings": [
-	  {
-		"key": "circ-chart-field",
-		"name": "Field to display head circumference chart",
-		"type": "field-list"
-	  },
-	  {
-		"key": "height-chart-field",
-		"name": "Field to display height chart",
-		"type": "field-list"
-	  },
-	  {
-		"key": "weight-chart-field",
-		"name": "Field to display weight chart",
-		"type": "field-list"
-	  },
-	  {
-		"key": "sex-field",
-		"name": "Field for child's sex",
-		"type": "field-list"
-	  },
-	  {
-		"key": "male-value",
-		"name": "Raw coded value for Male",
-		"type": "text"
-	  },
-	  {
-		"key": "female-value",
-		"name": "Raw coded value for Female",
-		"type": "text"
-	  },
-	  {
-		"key": "gestational-age-field",
-		"name": "Field for gestational age at birth (in weeks)",
-		"type": "field-list"
-	  },
-	  {
-		"key": "age-field",
-		"name": "Field for child's age (in months)",
-		"type": "field-list"
-	  },
-	  {
-		"key": "height-field",
-		"name": "Field for child's height",
-		"type": "field-list"
-	  },
-	  {
-		"key": "weight-field",
-		"name": "Field for child's weight",
-		"type": "field-list"
-	  },
-	  {
-		"key": "circumference-field",
-		"name": "Field for child's head circumference",
-		"type": "field-list"
-	  },
-	  {
-		"key": "circ-zscore-field",
-		"name": "Field to save head circumference zscore to (optional)",
-		"type": "field-list"
-	  },
-	  {
-		"key": "circ-percentile-field",
-		"name": "Field to save head circumference percentile to (optional)",
-		"type": "field-list"
-	  },
-	  {
-		"key": "height-zscore-field",
-		"name": "Field to save height zscore to (optional)",
-		"type": "field-list"
-	  },
-	  {
-		"key": "height-percentile-field",
-		"name": "Field to save height percentile to (optional)",
-		"type": "field-list"
-	  },
-	  {
-		"key": "weight-zscore-field",
-		"name": "Field to save weight zscore to (optional)",
-		"type": "field-list"
-	  },
-	  {
-		"key": "weight-percentile-field",
-		"name": "Field to save weight percentile to (optional)",
-		"type": "field-list"
-	  },
-	  {
-		"key": "debug-mode",
-		"name": "Enable debug mode for image area calibration",
-		"type": "checkbox"
-	  }
-	]
+    "project-settings": [
+        {
+            "key": "circ-chart-field",
+            "name": "Field to display head circumference chart",
+            "type": "field-list",
+            "autocomplete": true
+        },
+        {
+            "key": "height-chart-field",
+            "name": "Field to display height chart",
+            "type": "field-list",
+            "autocomplete": true
+        },
+        {
+            "key": "weight-chart-field",
+            "name": "Field to display weight chart",
+            "type": "field-list",
+            "autocomplete": true
+        },
+        {
+            "key": "sex-field",
+            "name": "Field for child's sex",
+            "type": "field-list",
+            "autocomplete": true
+        },
+        {
+            "key": "male-value",
+            "name": "Raw coded value for Male",
+            "type": "text"
+        },
+        {
+            "key": "female-value",
+            "name": "Raw coded value for Female",
+            "type": "text"
+        },
+        {
+            "key": "gestational-age-field",
+            "name": "Field for gestational age at birth (in weeks)",
+            "type": "field-list",
+            "autocomplete": true
+        },
+        {
+            "key": "age-field",
+            "name": "Field for child's age (in months)",
+            "type": "field-list",
+            "autocomplete": true
+        },
+        {
+            "key": "height-field",
+            "name": "Field for child's height",
+            "type": "field-list",
+            "autocomplete": true
+        },
+        {
+            "key": "weight-field",
+            "name": "Field for child's weight",
+            "type": "field-list",
+            "autocomplete": true
+        },
+        {
+            "key": "circumference-field",
+            "name": "Field for child's head circumference",
+            "type": "field-list",
+            "autocomplete": true
+        },
+        {
+            "key": "circ-zscore-field",
+            "name": "Field to save head circumference zscore to (optional)",
+            "type": "field-list",
+            "autocomplete": true
+        },
+        {
+            "key": "circ-percentile-field",
+            "name": "Field to save head circumference percentile to (optional)",
+            "type": "field-list",
+            "autocomplete": true
+        },
+        {
+            "key": "height-zscore-field",
+            "name": "Field to save height zscore to (optional)",
+            "type": "field-list",
+            "autocomplete": true
+        },
+        {
+            "key": "height-percentile-field",
+            "name": "Field to save height percentile to (optional)",
+            "type": "field-list",
+            "autocomplete": true
+        },
+        {
+            "key": "weight-zscore-field",
+            "name": "Field to save weight zscore to (optional)",
+            "type": "field-list",
+            "autocomplete": true
+        },
+        {
+            "key": "weight-percentile-field",
+            "name": "Field to save weight percentile to (optional)",
+            "type": "field-list",
+            "autocomplete": true
+        },
+        {
+            "key": "debug-mode",
+            "name": "Enable debug mode for image area calibration",
+            "type": "checkbox"
+        }
+    ]
 }

--- a/updateImage.php
+++ b/updateImage.php
@@ -27,7 +27,7 @@ if($userRights !== NULL) {
 		die();
 	}
 	
-	list($sex,$age,$circumference,$height,$weight,$useFentonChart) =
+	list($sex,$age,$circumference,$height,$weight,$useFentonChart, $highlightedDatumIndex) =
 		$module->getChartDataForRecord($project_id,$record,$event,$instrument,$repeatInstance,$thisAge,$thisValue,$chartType);
 	
 	$headChartField = $module->getProjectSetting("circ-chart-field");
@@ -69,7 +69,7 @@ if($userRights !== NULL) {
 	}
 	
 	if($chartDetails) {
-		list($instanceX,$instanceY,$x,$y) = $module->calculateXY($chartDetails,$age,$values,$repeatInstance);
+		list($instanceX,$instanceY,$x,$y) = $module->calculateXY($chartDetails,$age,$values,$highlightedDatumIndex);
 		
 		$returnValues = [
 			"chartType" => $chartType,


### PR DESCRIPTION
This adds support for longitudinal projects which do not have repeating instances or events (i.e. the XML provided by the client requesting this update). Note that longitudinal projects will follow a separate logical path for fetching and processing data, making them unable to also support repeating instances.

Additionally, I added `autocomplete` to all field settings ~~because I am far too lazy to manually copy that many values from the codebook~~ to improve the user experience during module configuration.

Attached is an export of the data which I used to test this module (I fabricated the values, despite her inspiring recovery to average metrics this person did not manage to exist thus her health information is not owed privacy):
[head_circumference_testing_data.csv](https://github.com/user-attachments/files/16397028/head_circumference_testing_data.csv)

---

## Caveats

While I did attempt to leave support for repeating instance-based projects, the only projects I saw on Vanderbilt's production REDCap which used this module were marked as completed ~2 years ago so I did not actually test projects designed around repeating instances myself.

I'm unsure if this is a bug, but when the WHO plots are drawn (6 month & 12 month), only 3 of the 5 data points are plotted (0 months & 1 month are excluded).