### PR TITLE
Skip events without age data if not currently entering relevant data

### DIFF
--- a/HeadCircChart.php
+++ b/HeadCircChart.php
@@ -215,6 +215,8 @@ class HeadCircChart extends AbstractExternalModule
 		$foundInstance = false;
 		$i = 1;
 		foreach($recordData as $eventDetails) {
+			// ignore events that don't contain any age data at all to prevent crashes during calculation attempts
+			if ($eventDetails[$ageField] === "" && !$eventDetails[self::CUR_VALUE_FLAG_NAME]) { continue; }
 			if($eventDetails[$sexField] !== "") {
 				$sex = ($eventDetails[$sexField] === (string)$femaleValue ? "2" :
 					($eventDetails[$sexField] === (string)$maleValue ? "1" : false));

--- a/HeadCircChart.php
+++ b/HeadCircChart.php
@@ -216,7 +216,11 @@ class HeadCircChart extends AbstractExternalModule
 		$i = 1;
 		foreach($recordData as $eventDetails) {
 			// ignore events that don't contain any age data at all to prevent crashes during calculation attempts
-			if ($eventDetails[$ageField] === "" && !$eventDetails[self::CUR_VALUE_FLAG_NAME]) { continue; }
+			if ($eventDetails[$ageField] === "") {
+				if (!$eventDetails[self::CUR_VALUE_FLAG_NAME]) { continue; }
+				// prevent issues with loading data entry page for first time on record
+				if (!$tempAge) { continue; }
+			}
 			if($eventDetails[$sexField] !== "") {
 				$sex = ($eventDetails[$sexField] === (string)$femaleValue ? "2" :
 					($eventDetails[$sexField] === (string)$maleValue ? "1" : false));


### PR DESCRIPTION
Prevents attempts to compare uninitiated values when `gestationalAge` is set before the first set of measurements are collected.